### PR TITLE
Duplicate sources.list entry http://dl.google.com/linux/chrome/deb/ stable/main amd64 Packages

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -39,7 +39,6 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y  zip \
                         fontconfig \
                         apt-transport-https \
-                        google-chrome-unstable \
 			gconf2 \
                         --no-install-recommends && \
     apt-get install -y  nodejs \


### PR DESCRIPTION
The usage of
```
apt-get install google-chrome-unstable
```
and
```
echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
```
ends in a

```
W: Duplicate sources.list entry http://dl.google.com/linux/chrome/deb/ stable/main amd64 Packages (/var/lib/apt/lists/dl.google.com_linux_chrome_deb_dists_stable_main_binary-amd64_Packages.gz)
W: You may want to run apt-get update to correct these problems
W: Duplicate sources.list entry http://dl.google.com/linux/chrome/deb/ stable/main amd64 Packages (/var/lib/apt/lists/dl.google.com_linux_chrome_deb_dists_stable_main_binary-amd64_Packages.gz)
W: You may want to run apt-get update to correct these problems
```