### PR TITLE
Added note about GitPitch Enterprise availability to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # GitPitch Container
 
-> GitPitch now offers [GitPitch Enterprise](https://gitpitch.com/pricing), the official Docker
-container for GitPitch which runs the same enhanced server
-that runs on [gitpitch.com](https://gitpitch.com).
+> This is an unofficial Docker container for GitPitch. GitPitch
+itself now offers [GitPitch Enterprise](https://gitpitch.com/pricing), the official Docker container for GitPitch which runs the same enhanced server that runs on [gitpitch.com](https://gitpitch.com).
 
 It's recommended to run the container with `docker-compose` because there are a few environment variables and it's easier to configure them all in one `docker-compose.yml` than passing them all in one `docker run` statement.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # GitPitch Container
 
+> GitPitch now offers [GitPitch Enterprise](https://gitpitch.com/pricing), the official Docker
+container for GitPitch which runs the same enhanced server
+that runs on [gitpitch.com](https://gitpitch.com).
+
 It's recommended to run the container with `docker-compose` because there are a few environment variables and it's easier to configure them all in one `docker-compose.yml` than passing them all in one `docker run` statement.
 
 But if you want to, you could run the container like this:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # GitPitch Container
 
-> This is an unofficial Docker container for GitPitch. GitPitch
-itself now offers [GitPitch Enterprise](https://gitpitch.com/pricing), the official Docker container for GitPitch which runs the same enhanced server that runs on [gitpitch.com](https://gitpitch.com).
+> This is an unofficial Docker container for the open-source GitPitch server. GitPitch itself now offers [GitPitch Enterprise](https://gitpitch.com/pricing), the official Docker container for GitPitch which runs the same enhanced server that runs on [gitpitch.com](https://gitpitch.com).
 
 It's recommended to run the container with `docker-compose` because there are a few environment variables and it's easier to configure them all in one `docker-compose.yml` than passing them all in one `docker run` statement.
 


### PR DESCRIPTION
Hi Peter, I've recently [announced](https://medium.com/search?q=gitpitch%20docker) official support for GitPitch Enterprise, the GitPitch Pro server delivered using Docker. I'm wondering would you be kind enough to add this note to the README in your repo? Thanks, David.