### PR TITLE
Add example for accessing by IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Have a look at the following section containing all available environment variab
 
 | Variable        | Explanation                                                      | Example                                                          |
 | --------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `GP_HOST`       | Host binding                                                     | localhost:9000                                                   |
+| `GP_HOST`       | Host binding                                                     | localhost:9000 or 192.168.0.2                                    |
 | `GP_APP_SECRET` | Play Framework crypto secret (random will be created if not set) | QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n |
 
 ## GitHub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   gitpitch:
     image: knsit/gitpitch:latest
     environment:
+      - "GP_HOST=192.168.0.2"
       - "GP_GITLAB_BASE=https://gitlab.com/"
       - "GP_GITLAB_API=https://gitlab.com/api/v4/"
       - "GP_GITLAB_AS_DEFAULT=true"


### PR DESCRIPTION
Please see https://github.com/kns-it/Docker-GitPitch/issues/7

I'm not sure how GP_HOST works but I made my gitlab work at last with this change.

This is my docker-compose.yml.
```
version: '3'
services:
  gitpitch:
    image: knsit/gitpitch:latest
    environment:
      - "GP_GITLAB_BASE=https://gitlab.com/"
      - "GP_HOST=192.168.0.27"
      - "GP_GITLAB_API=https://gitlab.com/api/v4/"
      - "GP_GITLAB_ACCESS_TOKEN=aaaaaaaaaaaaaaa"
      - "GP_GITLAB_AS_DEFAULT=true"
    ports:
      - 9000:9000
```

Then I accessed to my gitpitch with the url "http://192.168.0.27:9000/name/proj" because I run it in a vm of Virtualbox.

Thank you.